### PR TITLE
Fix require erb bug

### DIFF
--- a/lib/self_data.rb
+++ b/lib/self_data.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "erb"
 require "yaml"
 require "json"
 


### PR DESCRIPTION
This code:
``` ruby
require 'self_data'
puts SelfData.load
__END__
Kek
```
will produce:
`
'rescue in block in load': erb: #<NameError: uninitialized constant ERB> (SelfData::ConversionError)
`

without these changes.